### PR TITLE
Remove size restriction of repo

### DIFF
--- a/README_DETAIL.md
+++ b/README_DETAIL.md
@@ -8,8 +8,6 @@ Will this project take up a lot of GitHub resources?
 ---------------
 No.
 
-There are limitations on GitHub: The max size of a repo is 1024MB.
-
 Contributors are required to compress their photos before making pull requests. Photos which are larger than 1MB per file or don't meet our standard will be rejected. It's also considered to be a training course of GitHub workflow for them.
 
 In the future, we might clean orphaned objects regularly to keep the availability of the repo.


### PR DESCRIPTION
Github removed restriction on repos size and just "recommend repos remain small":
> We recommend repositories remain small, ideally less than 1 GB, and less than 5 GB is strongly recommended. Smaller repositories are faster to clone and easier to work with and maintain. If your repository excessively impacts our infrastructure, you might receive an email from GitHub Support asking you to take corrective action. We try to be flexible, especially with large projects that have many collaborators, and will work with you to find a resolution whenever possible. You can prevent your repository from impacting our infrastructure by effectively managing your repository's size and overall health. You can find advice and a tool for repository analysis in the [github/git-sizer](https://github.com/github/git-sizer) repository.

See [official docs](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github#repository-size-limits) to learn more.